### PR TITLE
GraphQLArgument annotation

### DIFF
--- a/example/example-client/src/main/java/co/uk/jacobmountain/MatchResultsClient.java
+++ b/example/example-client/src/main/java/co/uk/jacobmountain/MatchResultsClient.java
@@ -24,4 +24,7 @@ public interface MatchResultsClient {
     @GraphQLQuery("result")
     Optional<MatchResult> getResultOptional(int id);
 
+    @GraphQLQuery("result")
+    MatchResult getResultWithRenamedArg(@GraphQLArgument("id") int integer);
+
 }

--- a/example/example-client/src/test/groovy/co/uk/jacobmountain/ClientSpec.groovy
+++ b/example/example-client/src/test/groovy/co/uk/jacobmountain/ClientSpec.groovy
@@ -60,14 +60,26 @@ class ClientSpec extends Specification {
     def "I can get a query and wrap it in an Optional"() {
         given:
         def expected = RandomResultUtil.randomResult()
-        mock.getResult(1) >> expected
+        mock.getResult(2) >> expected
 
         when:
-        def result = client.getResultOptional(1)
+        def result = client.getResultOptional(2)
 
         then:
         result != null
         Assert.assertEquals(expected, result.orElse(null))
+    }
+
+    def "I can get a query with a parameter named differently to its argument"() {
+        given:
+        def expected = RandomResultUtil.randomResult()
+        mock.getResult(3) >> expected
+
+        when:
+        def result = client.getResultWithRenamedArg(3)
+
+        then:
+        Assert.assertEquals(expected, result)
     }
 
 

--- a/graphql-client-annotations/src/main/java/co/uk/jacobmountain/GraphQLArgument.java
+++ b/graphql-client-annotations/src/main/java/co/uk/jacobmountain/GraphQLArgument.java
@@ -1,0 +1,7 @@
+package co.uk.jacobmountain;
+
+public @interface GraphQLArgument {
+
+    String value();
+
+}

--- a/graphql-client-processor/src/main/java/co/uk/jacobmountain/ClientGenerator.java
+++ b/graphql-client-processor/src/main/java/co/uk/jacobmountain/ClientGenerator.java
@@ -3,6 +3,7 @@ package co.uk.jacobmountain;
 import co.uk.jacobmountain.utils.StringUtils;
 import co.uk.jacobmountain.visitor.MethodDetails;
 import co.uk.jacobmountain.visitor.MethodDetailsVisitor;
+import co.uk.jacobmountain.visitor.Parameter;
 import com.squareup.javapoet.*;
 import graphql.schema.idl.TypeDefinitionRegistry;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import static graphql.language.TypeName.newTypeName;
 
@@ -92,7 +94,7 @@ public class ClientGenerator {
         MethodSpec.Builder builder = MethodSpec.methodBuilder(method.getSimpleName().toString())
                 .returns(details.getReturnType())
                 .addModifiers(Modifier.PUBLIC)
-                .addParameters(details.getParameters());
+                .addParameters(details.getParameters().stream().map(Parameter::toSpec).collect(Collectors.toList()));
         assembleArguments(details).forEach(builder::addStatement);
         assembleFetchAndReturn(details, schema).forEach(builder::addStatement);
         return builder.build();
@@ -135,7 +137,7 @@ public class ClientGenerator {
     }
 
     private List<CodeBlock> assembleArguments(MethodDetails details) {
-        List<ParameterSpec> parameters = details.getParameters();
+        List<Parameter> parameters = details.getParameters();
         if (parameters.isEmpty()) {
             return Collections.emptyList();
         }
@@ -143,7 +145,13 @@ public class ClientGenerator {
         TypeName type = ClassName.get(dtoPackageName, generateArgumentClassname(details.getField()));
         ret.add(CodeBlock.of("$T args = new $T()", type, type));
         details.getParameters()
-                .forEach(param -> ret.add(CodeBlock.of("args.set$L($L)", StringUtils.capitalize(param.name), param.name)));
+                .forEach(param -> {
+                    String parameter = param.getName();
+                    String field = Optional.ofNullable(param.getAnnotation())
+                            .map(GraphQLArgument::value)
+                            .orElse(parameter);
+                    ret.add(CodeBlock.of("args.set$L($L)", StringUtils.capitalize(field), parameter));
+                });
         return ret;
     }
 

--- a/graphql-client-processor/src/main/java/co/uk/jacobmountain/DTOGenerator.java
+++ b/graphql-client-processor/src/main/java/co/uk/jacobmountain/DTOGenerator.java
@@ -47,9 +47,7 @@ public class DTOGenerator {
                 .forEach(details -> {
                     PojoBuilder builder = PojoBuilder.newClass(ClientGenerator.generateArgumentClassname(details.getField()), packageName);
                     details.getParameters()
-                            .forEach(variable -> {
-                                builder.withField(variable.type, variable.name);
-                            });
+                            .forEach(variable -> builder.withField(variable.getType(), variable.getName()));
                     try {
                         builder.build().writeTo(filer);
                     } catch (IOException e) {

--- a/graphql-client-processor/src/main/java/co/uk/jacobmountain/DTOGenerator.java
+++ b/graphql-client-processor/src/main/java/co/uk/jacobmountain/DTOGenerator.java
@@ -1,5 +1,6 @@
 package co.uk.jacobmountain;
 
+import co.uk.jacobmountain.visitor.MethodDetails;
 import co.uk.jacobmountain.visitor.MethodDetailsVisitor;
 import graphql.language.*;
 import lombok.extern.slf4j.Slf4j;
@@ -43,7 +44,7 @@ public class DTOGenerator {
         client.getEnclosedElements()
                 .stream()
                 .map(method -> method.accept(new MethodDetailsVisitor(), typeMapper))
-                .filter(details -> !details.getParameters().isEmpty()) // don't generate argument classes for methods without args
+                .filter(MethodDetails::hasParameters) // don't generate argument classes for methods without args
                 .forEach(details -> {
                     PojoBuilder builder = PojoBuilder.newClass(ClientGenerator.generateArgumentClassname(details.getField()), packageName);
                     details.getParameters()

--- a/graphql-client-processor/src/main/java/co/uk/jacobmountain/visitor/MethodDetails.java
+++ b/graphql-client-processor/src/main/java/co/uk/jacobmountain/visitor/MethodDetails.java
@@ -1,6 +1,5 @@
 package co.uk.jacobmountain.visitor;
 
-import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeName;
 import lombok.Builder;
 import lombok.Singular;
@@ -15,7 +14,7 @@ public class MethodDetails {
     private final String field;
 
     @Singular
-    private final List<ParameterSpec> parameters;
+    private final List<Parameter> parameters;
 
     private final boolean mutation;
 
@@ -31,7 +30,7 @@ public class MethodDetails {
         return !parameters.isEmpty();
     }
 
-    public List<ParameterSpec> getParameters() {
+    public List<Parameter> getParameters() {
         return parameters;
     }
 

--- a/graphql-client-processor/src/main/java/co/uk/jacobmountain/visitor/MethodDetails.java
+++ b/graphql-client-processor/src/main/java/co/uk/jacobmountain/visitor/MethodDetails.java
@@ -1,10 +1,12 @@
 package co.uk.jacobmountain.visitor;
 
+import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeName;
 import lombok.Builder;
 import lombok.Singular;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Builder
 public class MethodDetails {
@@ -32,6 +34,12 @@ public class MethodDetails {
 
     public List<Parameter> getParameters() {
         return parameters;
+    }
+
+    public List<ParameterSpec> getParameterSpec() {
+        return parameters.stream()
+                .map(Parameter::toSpec)
+                .collect(Collectors.toList());
     }
 
     public boolean isQuery() {

--- a/graphql-client-processor/src/main/java/co/uk/jacobmountain/visitor/MethodDetailsVisitor.java
+++ b/graphql-client-processor/src/main/java/co/uk/jacobmountain/visitor/MethodDetailsVisitor.java
@@ -1,9 +1,9 @@
 package co.uk.jacobmountain.visitor;
 
+import co.uk.jacobmountain.GraphQLArgument;
 import co.uk.jacobmountain.GraphQLQuery;
 import co.uk.jacobmountain.TypeMapper;
 import com.squareup.javapoet.ClassName;
-import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.TypeName;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,10 +23,11 @@ public class MethodDetailsVisitor extends ElementKindVisitor8<MethodDetails, Typ
                 .parameters(
                         e.getParameters()
                                 .stream()
-                                .map(parameter -> ParameterSpec.builder(
-                                        typeMapper.defaultPackage(ClassName.get(parameter.asType())),
-                                        parameter.getSimpleName().toString()
-                                        ).build()
+                                .map(parameter -> Parameter.builder()
+                                        .type(typeMapper.defaultPackage(ClassName.get(parameter.asType())))
+                                        .name(parameter.getSimpleName().toString())
+                                        .annotation(parameter.getAnnotation(GraphQLArgument.class))
+                                        .build()
                                 )
                                 .collect(Collectors.toList())
                 )

--- a/graphql-client-processor/src/main/java/co/uk/jacobmountain/visitor/Parameter.java
+++ b/graphql-client-processor/src/main/java/co/uk/jacobmountain/visitor/Parameter.java
@@ -1,0 +1,23 @@
+package co.uk.jacobmountain.visitor;
+
+import co.uk.jacobmountain.GraphQLArgument;
+import com.squareup.javapoet.ParameterSpec;
+import com.squareup.javapoet.TypeName;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class Parameter {
+
+    private TypeName type;
+
+    private String name;
+
+    private GraphQLArgument annotation;
+
+    public ParameterSpec toSpec() {
+        return ParameterSpec.builder(type, name).build();
+    }
+
+}


### PR DESCRIPTION
An annotation (`@GraphQLArgument("id")`) that allows for java arguments to be named differently to their GraphQL counterparts.

Using this client interface code:
```java
    @GraphQLQuery("droid")
    MatchResult getDroidById(@GraphQLArgument("id") int droid);
```
will now generate this query:
```graphQL
query Result($id: ID) { 
    droid(id: $id) { 
        id
        name
        __typename
    }
}
```
without the annotation, the `$id` argument would be named droid