### PR TITLE
Max depth per query

### DIFF
--- a/docs/refs/annotations.md
+++ b/docs/refs/annotations.md
@@ -7,7 +7,6 @@
     mapping = {
         @GraphQLClient.Scalar(from = "ID", to = String.class)
     },
-    maxDepth = 3,
     nullChecking = true,
     implSuffix = "Graph",
     reactive = false,
@@ -77,33 +76,6 @@ public interface MyClient {
             </td>
             <td>
                 empty list
-            </td>
-        </tr>
-        <tr>
-            <td rowspan="3">
-                <code>maxDepth</code>
-            </td>
-            <td>
-                Description
-            </td>
-            <td>
-                Used for the query generation, will only select children of object types up until this depth
-            </td>
-        </tr>
-        <tr>
-            <td>
-                required
-            </td>
-            <td>
-                false
-            </td>
-        </tr>
-        <tr>
-            <td>
-                default
-            </td>
-            <td>
-                3
             </td>
         </tr>
         <tr>
@@ -198,7 +170,8 @@ public interface MyClient {
 ## @GraphQLQuery
 ```java
 @GraphQLQuery(
-    value = "field"
+    value = "field",
+    maxDepth = 5
 )
 public Field getField();
 ```
@@ -237,13 +210,41 @@ public Field getField();
                 false
             </td>
         </tr>
+        <tr>
+            <td rowspan="3">
+                <code>maxDepth</code>
+            </td>
+            <td>
+                Description
+            </td>
+            <td>
+                Used for the query generation, will only select children of object types up until this depth
+            </td>
+        </tr>
+        <tr>
+            <td>
+                required
+            </td>
+            <td>
+                false
+            </td>
+        </tr>
+        <tr>
+            <td>
+                default
+            </td>
+            <td>
+                3
+            </td>
+        </tr>
     </tbody>
 </table>
 
 ## @GraphQLMutation
 ```java
 @GraphQLMutation(
-    value = "field"
+    value = "field",
+    maxDepth = 5
 )
 ```
 #### Fields:
@@ -281,13 +282,41 @@ public Field getField();
                 false
             </td>
         </tr>
+        <tr>
+            <td rowspan="3">
+                <code>maxDepth</code>
+            </td>
+            <td>
+                Description
+            </td>
+            <td>
+                Used for the query generation, will only select children of object types up until this depth
+            </td>
+        </tr>
+        <tr>
+            <td>
+                required
+            </td>
+            <td>
+                false
+            </td>
+        </tr>
+        <tr>
+            <td>
+                default
+            </td>
+            <td>
+                5
+            </td>
+        </tr>
     </tbody>
 </table>
 
 ## @GraphQLSubscription
 ```java
 @GraphQLSubscription(
-    value = "field"
+    value = "field",
+    maxDepth = 5
 )
 ```
 !> requires `@GraphQLClient(reactive = true)`
@@ -324,6 +353,33 @@ public Field getField();
             </td>
             <td>
                 false
+            </td>
+        </tr>
+        <tr>
+            <td rowspan="3">
+                <code>maxDepth</code>
+            </td>
+            <td>
+                Description
+            </td>
+            <td>
+                Used for the query generation, will only select children of object types up until this depth
+            </td>
+        </tr>
+        <tr>
+            <td>
+                required
+            </td>
+            <td>
+                false
+            </td>
+        </tr>
+        <tr>
+            <td>
+                default
+            </td>
+            <td>
+                5
             </td>
         </tr>
     </tbody>

--- a/example/example-client/src/main/java/com/jacobmountain/ReactiveStarWarsClient.java
+++ b/example/example-client/src/main/java/com/jacobmountain/ReactiveStarWarsClient.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 
 @GraphQLClient(
         schema = "Schema.gql",
-        maxDepth = 5,
         nullChecking = true,
         reactive = true
 )

--- a/example/example-client/src/main/java/com/jacobmountain/StarWarsClient.java
+++ b/example/example-client/src/main/java/com/jacobmountain/StarWarsClient.java
@@ -15,7 +15,6 @@ import java.util.Optional;
 
 @GraphQLClient(
         schema = "Schema.gql",
-        maxDepth = 5,
         nullChecking = true
 )
 public interface StarWarsClient {

--- a/graphql-java-client-annotations/src/main/java/com/jacobmountain/graphql/client/annotations/GraphQLClient.java
+++ b/graphql-java-client-annotations/src/main/java/com/jacobmountain/graphql/client/annotations/GraphQLClient.java
@@ -13,8 +13,6 @@ public @interface GraphQLClient {
 
     Scalar[] mapping() default {};
 
-    int maxDepth() default 3;
-
     boolean nullChecking() default false;
 
     String implSuffix() default "Graph";

--- a/graphql-java-client-annotations/src/main/java/com/jacobmountain/graphql/client/annotations/GraphQLMutation.java
+++ b/graphql-java-client-annotations/src/main/java/com/jacobmountain/graphql/client/annotations/GraphQLMutation.java
@@ -19,4 +19,6 @@ public @interface GraphQLMutation {
      */
     String name() default "";
 
+    int maxDepth() default 5;
+
 }

--- a/graphql-java-client-annotations/src/main/java/com/jacobmountain/graphql/client/annotations/GraphQLQuery.java
+++ b/graphql-java-client-annotations/src/main/java/com/jacobmountain/graphql/client/annotations/GraphQLQuery.java
@@ -19,4 +19,6 @@ public @interface GraphQLQuery {
      */
     String name() default "";
 
+    int maxDepth() default 5;
+
 }

--- a/graphql-java-client-annotations/src/main/java/com/jacobmountain/graphql/client/annotations/GraphQLSubscription.java
+++ b/graphql-java-client-annotations/src/main/java/com/jacobmountain/graphql/client/annotations/GraphQLSubscription.java
@@ -19,4 +19,6 @@ public @interface GraphQLSubscription {
      */
     String name() default "";
 
+    int maxDepth() default 5;
+
 }

--- a/graphql-java-client-processor/src/main/java/com/jacobmountain/graphql/client/ClientGenerator.java
+++ b/graphql-java-client-processor/src/main/java/com/jacobmountain/graphql/client/ClientGenerator.java
@@ -41,17 +41,17 @@ public class ClientGenerator {
 
     private final AbstractStage returnResults;
 
-    public ClientGenerator(Filer filer, int maxDepth, TypeMapper typeMapper, String packageName, String dtoPackageName, Schema schema, boolean reactive) {
+    public ClientGenerator(Filer filer, TypeMapper typeMapper, String packageName, String dtoPackageName, Schema schema, boolean reactive) {
         this.filer = filer;
         this.typeMapper = typeMapper;
         this.packageName = packageName;
         this.schema = schema;
         this.arguments = new ArgumentAssemblyStage(dtoPackageName);
         if (reactive) {
-            this.query = new ReactiveQueryStage(schema, typeMapper, dtoPackageName, maxDepth);
+            this.query = new ReactiveQueryStage(schema, typeMapper, dtoPackageName);
             this.returnResults = new ReactiveReturnStage(schema, typeMapper);
         } else {
-            this.query = new BlockingQueryStage(schema, typeMapper, dtoPackageName, maxDepth);
+            this.query = new BlockingQueryStage(schema, typeMapper, dtoPackageName);
             this.returnResults = new OptionalReturnStage(schema, typeMapper);
         }
     }

--- a/graphql-java-client-processor/src/main/java/com/jacobmountain/graphql/client/GraphQLClientProcessor.java
+++ b/graphql-java-client-processor/src/main/java/com/jacobmountain/graphql/client/GraphQLClientProcessor.java
@@ -74,7 +74,7 @@ public class GraphQLClientProcessor extends AbstractProcessor {
     private void generateClientImplementation(Input client) {
         GraphQLClient annotation = client.getAnnotation();
         log.info("Generating java implementation of {}", client.element.getSimpleName());
-        new ClientGenerator(this.filer, annotation.maxDepth(), client.getTypeMapper(), client.getPackage(), client.getDtoPackage(), client.getSchema(), annotation.reactive())
+        new ClientGenerator(this.filer, client.getTypeMapper(), client.getPackage(), client.getDtoPackage(), client.getSchema(), annotation.reactive())
                 .generate(client.element, annotation.implSuffix());
     }
 

--- a/graphql-java-client-processor/src/main/java/com/jacobmountain/graphql/client/modules/AbstractQueryStage.java
+++ b/graphql-java-client-processor/src/main/java/com/jacobmountain/graphql/client/modules/AbstractQueryStage.java
@@ -16,17 +16,14 @@ import java.util.stream.Collectors;
 
 public abstract class AbstractQueryStage extends AbstractStage {
 
-    private final int maxDepth;
-
     protected final TypeName query;
 
     protected final TypeName mutation;
 
     protected final TypeName subscription;
 
-    public AbstractQueryStage(Schema schema, TypeMapper typeMapper, String dtoPackageName, int maxDepth) {
+    public AbstractQueryStage(Schema schema, TypeMapper typeMapper, String dtoPackageName) {
         super(schema, typeMapper);
-        this.maxDepth = maxDepth;
         this.query = ClassName.get(dtoPackageName, schema.getQueryTypeName());
         this.mutation = schema.getMutationTypeName().map(it -> ClassName.get(dtoPackageName, it)).orElse(ClassName.get(Void.class));
         this.subscription = schema.getSubscriptionTypeName().map(it -> ClassName.get(dtoPackageName, it)).orElse(ClassName.get(Void.class));
@@ -57,7 +54,7 @@ public abstract class AbstractQueryStage extends AbstractStage {
                 .stream()
                 .map(Parameter::getField)
                 .collect(Collectors.toSet());
-        QueryGenerator queryGenerator = new QueryGenerator(schema, maxDepth);
+        QueryGenerator queryGenerator = new QueryGenerator(schema, details.getMaxDepth());
         String query;
         if (details.isQuery()) {
             query = queryGenerator.generateQuery(request, details.getField(), params);

--- a/graphql-java-client-processor/src/main/java/com/jacobmountain/graphql/client/modules/BlockingQueryStage.java
+++ b/graphql-java-client-processor/src/main/java/com/jacobmountain/graphql/client/modules/BlockingQueryStage.java
@@ -18,8 +18,8 @@ import java.util.stream.Stream;
 
 public class BlockingQueryStage extends AbstractQueryStage {
 
-    public BlockingQueryStage(Schema schema, TypeMapper typeMapper, String dtoPackageName, int maxDepth) {
-        super(schema, typeMapper, dtoPackageName, maxDepth);
+    public BlockingQueryStage(Schema schema, TypeMapper typeMapper, String dtoPackageName) {
+        super(schema, typeMapper, dtoPackageName);
     }
 
     private ParameterizedTypeName generateTypeName() {

--- a/graphql-java-client-processor/src/main/java/com/jacobmountain/graphql/client/modules/ReactiveQueryStage.java
+++ b/graphql-java-client-processor/src/main/java/com/jacobmountain/graphql/client/modules/ReactiveQueryStage.java
@@ -14,8 +14,8 @@ import java.util.List;
 
 public class ReactiveQueryStage extends AbstractQueryStage {
 
-    public ReactiveQueryStage(Schema schema, TypeMapper typeMapper, String dtoPackageName, int maxDepth) {
-        super(schema, typeMapper, dtoPackageName, maxDepth);
+    public ReactiveQueryStage(Schema schema, TypeMapper typeMapper, String dtoPackageName) {
+        super(schema, typeMapper, dtoPackageName);
     }
 
     private TypeName getFetcherTypeName() {

--- a/graphql-java-client-processor/src/main/java/com/jacobmountain/graphql/client/visitor/MethodDetails.java
+++ b/graphql-java-client-processor/src/main/java/com/jacobmountain/graphql/client/visitor/MethodDetails.java
@@ -24,11 +24,13 @@ public class MethodDetails {
     @Getter
     private final String requestName;
 
+    @Getter
     private final TypeName returnType;
 
     @Getter
     private final String field;
 
+    @Getter
     @Singular
     private final List<Parameter> parameters;
 
@@ -36,16 +38,12 @@ public class MethodDetails {
 
     private final boolean subscription;
 
-    public TypeName getReturnType() {
-        return returnType;
-    }
+    @Getter
+    private final int maxDepth;
+
 
     public boolean hasParameters() {
         return !parameters.isEmpty();
-    }
-
-    public List<Parameter> getParameters() {
-        return parameters;
     }
 
     public List<ParameterSpec> getParameterSpec() {

--- a/graphql-java-client-processor/src/main/java/com/jacobmountain/graphql/client/visitor/MethodDetailsVisitor.java
+++ b/graphql-java-client-processor/src/main/java/com/jacobmountain/graphql/client/visitor/MethodDetailsVisitor.java
@@ -49,6 +49,7 @@ public class MethodDetailsVisitor extends ElementKindVisitor8<MethodDetails, Typ
                         .field(annotation.value())
                         .mutation(false)
                         .subscription(false)
+                        .maxDepth(annotation.maxDepth())
                         .parameters(getParameters(e, typeMapper, annotation.value()))
                         .build());
     }
@@ -62,6 +63,7 @@ public class MethodDetailsVisitor extends ElementKindVisitor8<MethodDetails, Typ
                         .field(annotation.value())
                         .mutation(true)
                         .subscription(false)
+                        .maxDepth(annotation.maxDepth())
                         .parameters(getParameters(e, typeMapper, annotation.value()))
                         .build());
     }
@@ -75,6 +77,7 @@ public class MethodDetailsVisitor extends ElementKindVisitor8<MethodDetails, Typ
                         .field(annotation.value())
                         .mutation(false)
                         .subscription(true)
+                        .maxDepth(annotation.maxDepth())
                         .parameters(getParameters(e, typeMapper, annotation.value()))
                         .build()
                 );


### PR DESCRIPTION
Moves the `maxDepth` annotation property to the `@GraphQLQuery/@GraphQLMutation/@GraphQLSubscription` annotations and out of the `@GraphQLClient` annotation